### PR TITLE
Added related sorting and min similarity to 0.35

### DIFF
--- a/get_related_job.js
+++ b/get_related_job.js
@@ -24,7 +24,7 @@ async function getRelatedArticles () {
     console.log("RUNNING...");
 
     const timestampFrame = new Date(Date.now() - 6 * 60 * 60 * 1000);     //Timestamp for the timeframe of reads
-    const minimumSimilarity = 0.25;                                       //Minimum value of similarity to determine if two articles are similar
+    const minimumSimilarity = 0.35;                                       //Minimum value of similarity to determine if two articles are similar
 
     //Get a query reference snapshot from the last 24h for left, middle and right articles
     const queryLeftArticles = await db.collection("left-articles").where("timestamp", ">=", timestampFrame).get();
@@ -50,7 +50,9 @@ async function getRelatedArticles () {
 
                 //Determine if the similarity is above the minimum
                 if(similarity >= minimumSimilarity) {
-                    relatedArticles.push(d.id);   //Add the article to the related articles
+                
+                  //Add the article and its similarity score to the related articles
+                  relatedArticles.push({id: d.id, similarity: similarity});
                 }
             }
         });
@@ -67,12 +69,21 @@ async function getRelatedArticles () {
 
                 //Determine if the similarity is above the minimum
                 if(similarity >= minimumSimilarity) {
-                    relatedArticles.push(d.id);   //Add the article to the related articles
+                  
+                  //Add the article and its similarity score to the related articles
+                  relatedArticles.push({id: d.id, similarity: similarity});
                 }
             }
         });
 
-        const updatePromise = doc.ref.update({ "related_articles": relatedArticles })
+        //Sort the related articles by similarity in descending order
+        relatedArticles.sort((a, b) => b.similarity - a.similarity);
+
+        //Create a new array with only the article IDs
+        const relatedArticleIds = relatedArticles.map((article) => article.id);
+
+
+        const updatePromise = doc.ref.update({ "related_articles": relatedArticleIds })
             .then(() => {})
             .catch((error) => {
                 console.error('Error updating field: ', error);
@@ -98,7 +109,9 @@ async function getRelatedArticles () {
 
                 //Determine if the similarity is above the minimum
                 if(similarity >= minimumSimilarity) {
-                    relatedArticles.push(d.id);   //Add the article to the related articles
+
+                    //Add the article and its similarity score to the related articles
+                    relatedArticles.push({id: d.id, similarity: similarity});
                 }
             }
         });
@@ -106,21 +119,30 @@ async function getRelatedArticles () {
         //Go through all right articles to find related ones
         queryRightArticles.forEach((d) => {
             const data = d.data();
-
+          
             //Make sure it's not deleted
             if(data.deleted == false) {
-                
-                //Run a similarity check on the two titles
-                const similarity = stringSimilarity.compareTwoStrings(title, data.title);
-
-                //Determine if the similarity is above the minimum
-                if(similarity >= minimumSimilarity) {
-                    relatedArticles.push(d.id);   //Add the article to the related articles
-                }
+          
+              //Run a similarity check on the two titles
+              const similarity = stringSimilarity.compareTwoStrings(title, data.title);
+          
+              //Determine if the similarity is above the minimum
+              if(similarity >= minimumSimilarity) {
+          
+                //Add the article and its similarity score to the related articles
+                relatedArticles.push({id: d.id, similarity: similarity});
+              }
             }
         });
+          
+        //Sort the related articles by similarity in descending order
+        relatedArticles.sort((a, b) => b.similarity - a.similarity);
 
-        const updatePromise = doc.ref.update({ "related_articles": relatedArticles })
+        //Create a new array with only the article IDs
+        const relatedArticleIds = relatedArticles.map((article) => article.id);
+
+
+        const updatePromise = doc.ref.update({ "related_articles": relatedArticleIds })
             .then(() => {})
             .catch((error) => {
                 console.error('Error updating field: ', error);
@@ -146,7 +168,9 @@ async function getRelatedArticles () {
 
                 //Determine if the similarity is above the minimum
                 if(similarity >= minimumSimilarity) {
-                    relatedArticles.push(d.id);   //Add the article to the related articles
+                    
+                    //Add the article and its similarity score to the related articles
+                    relatedArticles.push({id: d.id, similarity: similarity});
                 }
             }
         });
@@ -163,12 +187,21 @@ async function getRelatedArticles () {
 
                 //Determine if the similarity is above the minimum
                 if(similarity >= minimumSimilarity) {
-                    relatedArticles.push(d.id);   //Add the article to the related articles
+                    
+                    //Add the article and its similarity score to the related articles
+                    relatedArticles.push({id: d.id, similarity: similarity});
                 }
             }
         });
 
-        const updatePromise = doc.ref.update({ "related_articles": relatedArticles })
+        //Sort the related articles by similarity in descending order
+        relatedArticles.sort((a, b) => b.similarity - a.similarity);
+
+        //Create a new array with only the article IDs
+        const relatedArticleIds = relatedArticles.map((article) => article.id);
+
+
+        const updatePromise = doc.ref.update({ "related_articles": relatedArticleIds })
             .then(() => {})
             .catch((error) => {
                 console.error('Error updating field: ', error);


### PR DESCRIPTION
This sorts the related articles based on their similarity rating, so the most similar appears first in the article.
Also changed the minimum similarity from 0.25 -> 0.35 to achieve more similar articles.
These changes where also applied to the trending related articles. 